### PR TITLE
fix: Issue template not rendering due to invalid syntax

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -124,11 +124,11 @@ body:
 
   - type: textarea
     attributes:
-      # label: Xhell version
-      # description: >-
-      # Paste verbatim output from `Xhell --version` below, under the prompt line.
-      # Don't wrap it with triple backticks &mdash; your whole input will be
-      # turned into a code snippet automatically.
+      label: Xhell version
+      description: >-
+        Paste verbatim output from `Xhell --version` below, under the prompt line.
+        Don't wrap it with triple backticks &mdash; your whole input will be
+        turned into a code snippet automatically.
       render: console
       placeholder: |
         python -m pip show Xhell


### PR DESCRIPTION
## Pull Request description

Bug report issue template isn't rendering since `label` is a required key
<img width="826" alt="Screenshot 2025-04-01 at 5 43 19 PM" src="https://github.com/user-attachments/assets/4f6dcfc2-faa7-4e48-afab-f1a73f585c50" />



<!-- Which issue this PR aims to resolve or fix? E.g.:
Fixes #4
-->

## How to test these changes

<!-- Example:

* run `$ abc -p 1234`
* open the web browser with url localhost:1234
* ...
-->

- `...`

<!-- Modify the options to suit your project. -->

## Pull Request checklists

This PR is a:

- [x] bug-fix

About this PR:

- [ ] it includes tests.
- [ ] the tests are executed on CI.
- [ ] the tests generate log file(s) (path).
- [ ] pre-commit hooks were executed locally.
- [ ] this PR requires a project documentation update.

Author's checklist:

- [x] I have reviewed the changes and it contains no misspelling.
- [x] The code is well commented, especially in the parts that contain more
      complexity.
- [x] New and old tests passed locally.

## Additional information

<!-- Add any screenshot that helps to show the changes proposed -->

<!-- Add any other extra information that would help to understand the changes proposed by this PR -->

## Reviewer's checklist

Copy and paste this template for your review's note:

```
## Reviewer's Checklist

- [ ] I managed to reproduce the problem locally from the `main` branch
- [ ] I managed to test the new changes locally
- [ ] I confirm that the issues mentioned were fixed/resolved
```
